### PR TITLE
fixed segfault on invalid check type

### DIFF
--- a/dynamicbeat/checks/checks.go
+++ b/dynamicbeat/checks/checks.go
@@ -3,7 +3,6 @@ package checks
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"html/template"
 	"sync"
 	"time"
@@ -129,7 +128,8 @@ func unpackDef(config schema.CheckConfig) schema.Check {
 	case "xmpp":
 		def = &xmpp.Definition{}
 	default:
-		fmt.Printf("\n\n[!] Add your definition to the switch case!\n\n")
+		logp.Warn("Invalid check type found. Offending check : %s:%s", config.Name, config.Type)
+		def = &noop.Definition{}
 	}
 	err = def.Init(config, renderedJSON)
 	if err != nil {


### PR DESCRIPTION
Closes #40

Fixed the seg fault issue by have the default case set the definition to `noop` which will make the check automatically pass, but you will get `WARN` log messages and other information to inform you of the issue.

![image](https://user-images.githubusercontent.com/29211904/78149478-0ae9b100-7404-11ea-85a8-3da1b7635a2e.png)

