### PR TITLE
Handle Dynamicbeat template errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Updated small/docker setup script to properly parse kibana password
 - Updated SSL configuration paths in example Dynamicbeat config
+- Fix template syntax error in `http-kolide` example check
+
+### Dynamicbeat
+
+#### Added
+
+- Report template failure errors in check results
+
+#### Fixed
+
+- Don't panic on invalid templates
+- Remove typo in ICMP definition struct field tag
 
 [0.6.0-rc2] - 2020-10-04
 ------------------------

--- a/dynamicbeat/.gitignore
+++ b/dynamicbeat/.gitignore
@@ -1,5 +1,6 @@
 /.idea
 /build
+/data
 
 .DS_Store
 /dynamicbeat

--- a/dynamicbeat/checks/checks.go
+++ b/dynamicbeat/checks/checks.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"html/template"
 	"reflect"
 	"strconv"
@@ -51,7 +52,26 @@ func RunChecks(defPass chan []schema.CheckConfig, pubQueue chan<- beat.Event) {
 	for _, def := range defs {
 		// checkName := def.Name
 		names[def.ID] = false
-		check := unpackDef(def)
+		check, err := unpackDef(def)
+		if err != nil {
+			// Something was wrong with templating the check. Return a failed event with the error.
+			errorDetail := make(map[string]string)
+			errorDetail["error_message"] = err.Error()
+			eventQueue <- beat.Event{
+				Timestamp: time.Now(),
+				Fields: common.MapStr{
+					"type":         "dynamicbeat",
+					"id":           check.GetConfig().ID,
+					"name":         check.GetConfig().Name,
+					"check_type":   check.GetConfig().Type,
+					"group":        check.GetConfig().Group,
+					"score_weight": check.GetConfig().ScoreWeight,
+					"passed":       false,
+					"message":      "Encountered an error when unpacking check definition.",
+					"details":      errorDetail,
+				},
+			}
+		}
 
 		// Start check goroutine
 		wg.Add(1)
@@ -93,26 +113,22 @@ func RunChecks(defPass chan []schema.CheckConfig, pubQueue chan<- beat.Event) {
 	}
 }
 
-func unpackDef(config schema.CheckConfig) schema.Check {
+func unpackDef(config schema.CheckConfig) (schema.Check, error) {
 	// Render any template strings in the definition
 	var renderedJSON []byte
 	templ := template.New("definition")
 	templ, err := templ.Parse(string(config.Definition))
 	if err != nil {
-		// If there was an error parsing the template, use the original string
-		logp.Warn("Failed to parse template for check '%s': %s", config.ID, err.Error())
-		renderedJSON = config.Definition
-	} else {
-		var buf bytes.Buffer
-		err := templ.Execute(&buf, config.Attribs)
-		if err != nil {
-			// If there was an error executing the template, use the original string
-			logp.Warn("Failed to execute template for check '%s': %s", config.ID, err.Error())
-			renderedJSON = config.Definition
-		} else {
-			renderedJSON = buf.Bytes()
-		}
+		return nil, fmt.Errorf("Failed to parse template for check: %s", err.Error())
 	}
+
+	var buf bytes.Buffer
+	err = templ.Execute(&buf, config.Attribs)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to execute template for check: %s", err.Error())
+	}
+
+	renderedJSON = buf.Bytes()
 
 	// Create a Definition from the rendered JSON string
 	var def schema.Check
@@ -154,7 +170,7 @@ func unpackDef(config schema.CheckConfig) schema.Check {
 		logp.Info("%s", err)
 	}
 
-	return def
+	return def, nil
 }
 
 func runCheck(ctx context.Context, check schema.Check) beat.Event {

--- a/dynamicbeat/checks/icmp/icmp.go
+++ b/dynamicbeat/checks/icmp/icmp.go
@@ -15,10 +15,10 @@ import (
 // it implements the "Check" interface
 type Definition struct {
 	Config          schema.CheckConfig // generic metadata about the check
-	Host            string             `optiontype:"required"`                       // IP or hostname of the host to run the ICMP check against
-	Count           int                `optiontype:"optional" optiondefault:"1"`     // The number of ICMP requests to send per check
-	AllowPacketLoss string             `optiontype:"optional" optionadefault:"true"` // Pass check based on received pings matching Count; if false, will use percent packet loss
-	Percent         int                `optiontype:"optional" optiondefault:"100"`   // Percent of packets needed to come back to pass the check
+	Host            string             `optiontype:"required"`                      // IP or hostname of the host to run the ICMP check against
+	Count           int                `optiontype:"optional" optiondefault:"1"`    // The number of ICMP requests to send per check
+	AllowPacketLoss string             `optiontype:"optional" optiondefault:"true"` // Pass check based on received pings matching Count; if false, will use percent packet loss
+	Percent         int                `optiontype:"optional" optiondefault:"100"`  // Percent of packets needed to come back to pass the check
 }
 
 // Run a single instance of the check

--- a/examples/http-kolide/check.json
+++ b/examples/http-kolide/check.json
@@ -5,7 +5,7 @@
     "group": "example",
     "score_weight": 1,
     "definition": {
-        "reportmatchedcontent": ".{{reportmatchedcontent}}",
+        "reportmatchedcontent": "{{.reportmatchedcontent}}",
         "requests": [
             {
                 "host": "{{.Host}}",


### PR DESCRIPTION
This PR also fixes the error in the check definition that caused this problem, fixes an unrelated error with the ICMP protocol, and adds reporting of template errors to the check results.