### PR TITLE
Use ICMP's Count field again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 #### Added
 
 - Report template failure errors in check results
+- Report ICMP packet statistics in check result details for failed checks
 
 #### Fixed
 
 - Don't panic on invalid templates
 - Remove typo in ICMP definition struct field tag
+- Don't ignore Count field in ICMP definition
 
 [0.6.0-rc2] - 2020-10-04
 ------------------------

--- a/dynamicbeat/checks/icmp/icmp.go
+++ b/dynamicbeat/checks/icmp/icmp.go
@@ -48,10 +48,13 @@ func (d *Definition) Run(ctx context.Context) schema.CheckResult {
 
 	stats := pinger.Statistics()
 
+	details := make(map[string]string)
 	// Check packet loss instead of count
 	if !passCount {
 		if stats.PacketLoss >= float64(d.Percent) {
 			result.Message = "Not all pings made it back!"
+			details["packetloss_percent"] = strconv.FormatFloat(stats.PacketLoss, 'f', -1, 64)
+			result.Details = details
 			return result
 		}
 
@@ -63,6 +66,9 @@ func (d *Definition) Run(ctx context.Context) schema.CheckResult {
 	// Check for failure of ICMP
 	if stats.PacketsRecv != d.Count {
 		result.Message = fmt.Sprint("Not all pings made it back!")
+		details["packets_received"] = fmt.Sprintf("%d", stats.PacketsRecv)
+		details["packets_expected"] = fmt.Sprintf("%d", d.Count)
+		result.Details = details
 		return result
 	}
 

--- a/dynamicbeat/checks/icmp/icmp.go
+++ b/dynamicbeat/checks/icmp/icmp.go
@@ -34,7 +34,7 @@ func (d *Definition) Run(ctx context.Context) schema.CheckResult {
 	}
 
 	// Send ping
-	pinger.Count = 3
+	pinger.Count = d.Count
 	// TODO: change this to be relative to the parent context's timeout
 	pinger.Timeout = 25 * time.Second
 	_ = pinger.Run()


### PR DESCRIPTION
The ICMP Count field was overridden to 3 back in February in the lead-up to ISTS, and it just never got switched back.