### PR TITLE
Document JQ Dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Each release in the changelog is divided into the following sections:
+
+- General: changes to anything other than the Dynamicbeat or Kibana plugin code
+- Dynamicbeat
+- Kibana plugin
+
+Each section organizes entries into the following subsections:
+
+- Added
+- Changed
+- Deprecated
+- Removed
+- Fixed
+- Security
+
 [Unreleased]
 ------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [Unreleased]
 ------------
 
+### General
+
+#### Fixed
+
+- Documented `add-team.sh`'s dependency on `jq` (#261)
+
 [0.6.0] - 2020-10-17
 --------------------
 

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -92,7 +92,9 @@ Similar to `admin-attribs.json`, `user-attribs.json` will allow both Users and A
 Adding Teams
 ------------
 
-Now that we know the folder structure for our checks as well as what attributes we want to make available to Admins and Users, we can now add a team and checks to Elastic and start scoring! To add a team with the checks you have configured, you will use the `add-team.sh` script. Before we run the script you will need to configure some values. Open the `add-team.sh` script in your editor of choice and modify the following values at the top of the file:
+Now that we know the folder structure for our checks as well as what attributes we want to make available to Admins and Users, we can now add a team and checks to Elastic and start scoring! To add a team with the checks you have configured, you will use the `add-team.sh` script. Please note that the `add-team.sh` script requires the [`jq`](https://stedolan.github.io/jq/) binary to be installed on your system.
+
+Before we run the script you will need to configure some values. Open the `add-team.sh` script in your editor of choice and modify the following values at the top of the file:
 
 ```
 ELASTICSEARCH_HOST=localhost:9200


### PR DESCRIPTION
Description
-----------

This adds to the documentation that the `add-team.sh` script requires JQ to be installed on the system.

Fixes #261

## Merge Checklist

- [ ] ~I have tested this change locally to make sure it works~ N/A
- [X] I have updated the documentation as necessary
- [X] I have added a release note under the [Unreleased section of the Changelog](../CHANGELOG.md#unreleased)
- [X] Any relevant labels have been added
- [X] This PR is being merged into `dev`, unless it's a PR for a release