### PR TITLE
Fix Elasticsearch bugs with small/docker

### DIFF
--- a/deployment/small/docker/docker-compose.yml
+++ b/deployment/small/docker/docker-compose.yml
@@ -24,7 +24,6 @@ services:
 
   elasticsearch:
     container_name: elasticsearch
-    env_file: elasticsearch.env
     environment:
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/deployment/small/docker/elasticsearch-memory.jvm.options
+++ b/deployment/small/docker/elasticsearch-memory.jvm.options
@@ -1,2 +1,2 @@
--Xms512mb
--Xmx512mb
+-Xms512m
+-Xmx512m


### PR DESCRIPTION
Description
-----------

This fixes a bad reference to the old `elasticsearch.env` file and corrects the syntax of the JVM heap specification in the small/docker deployment. These issues were introduced in #282.

No release notes have been added because this PR fixes an issue that was created within the release.

## Merge Checklist

- [X] I have tested this change locally to make sure it works
- [X] I have updated the documentation as necessary
- [ ] ~I have added a release note under the [Unreleased section of the Changelog](../CHANGELOG.md#unreleased)~
- [X] Any relevant labels have been added
- [X] This PR is being merged into `dev`, unless it's a PR for a release