### PR TITLE
Workaround for flashing dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Each section organizes entries into the following subsections:
 
 - Migrated documentation to `mdbook`
 - Changed WinRM example check's command to `whoami`
+- Adjusted default dashboard refresh time to 30 seconds (#284)
+- Standardized dashboard and visualization IDs (#284)
 
 #### Fixed
 

--- a/add-team.sh
+++ b/add-team.sh
@@ -69,7 +69,7 @@ do
   CHECKS=$(find examples -maxdepth 1 -mindepth 1 -type d -printf "%f\n" | wc -l)
   cat dashboards/single-team-overview.json | sed -e "s/\${TEAM}/${TEAM}/g" | sed -e "s/\${INDEX}/${INDEX}/g" | sed -e "s/\${CHECKS}/${CHECKS}/g" > tmp-dashboard.json
   curl -ku ${USERNAME}:${PASSWORD} https://${KIBANA_HOST}/api/kibana/dashboards/import -H "Content-Type: application/json" -H "kbn-xsrf: true" -d @tmp-dashboard.json
-  curl -kX POST -u ${USERNAME}:${PASSWORD} https://${KIBANA_HOST}/api/spaces/_copy_saved_objects -H 'Content-Type: application/json' -H 'kbn-xsrf: true' -d '{"spaces":["scorestack"],"objects":[{"type":"dashboard","id":"'scorestack-scoreboard'"}],"includeReferences":true}'
+  curl -kX POST -u ${USERNAME}:${PASSWORD} https://${KIBANA_HOST}/api/spaces/_copy_saved_objects -H 'Content-Type: application/json' -H 'kbn-xsrf: true' -d '{"spaces":["scorestack"],"objects":[{"type":"dashboard","id":"'scorestack-overview-${TEAM}'"}],"includeReferences":true}'
 done
 
 # Clean up

--- a/add-team.sh
+++ b/add-team.sh
@@ -21,18 +21,8 @@ do
 done
 
 # Add scoreboard dashboard
-UUID_A=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
-UUID_B=$(uuidgen)
-UUID_C=$(uuidgen)
-UUID_D=dddddddd-dddd-dddd-dddd-dddddddddddd
-UUID_E=eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee
-UUID_F=ffffffff-ffff-ffff-ffff-ffffffffffff
-cat dashboards/scoreboard.json | sed -e "s/\${UUID_A}/${UUID_A}/g" | sed -e "s/\${UUID_B}/${UUID_B}/g" | sed -e "s/\${UUID_C}/${UUID_C}/g" | sed -e "s/\${UUID_D}/${UUID_D}/g" | sed -e "s/\${UUID_E}/${UUID_E}/g" | sed -e "s/\${UUID_F}/${UUID_F}/g" > tmp-dashboard.json
-curl -ku ${USERNAME}:${PASSWORD} https://${KIBANA_HOST}/api/kibana/dashboards/import -H "Content-Type: application/json" -H "kbn-xsrf: true" -d @tmp-dashboard.json
-curl -kX POST -u ${USERNAME}:${PASSWORD} https://${KIBANA_HOST}/api/spaces/_copy_saved_objects -H 'Content-Type: application/json' -H 'kbn-xsrf: true' -d '{"spaces":["scorestack"],"objects":[{"type":"dashboard","id":"'${UUID_A}'"}],"includeReferences":true}'
-
-# Clean up
-rm tmp-dashboard.json
+curl -ku ${USERNAME}:${PASSWORD} https://${KIBANA_HOST}/api/kibana/dashboards/import -H "Content-Type: application/json" -H "kbn-xsrf: true" -d @dashboards/scoreboard.json
+curl -kX POST -u ${USERNAME}:${PASSWORD} https://${KIBANA_HOST}/api/spaces/_copy_saved_objects -H 'Content-Type: application/json' -H 'kbn-xsrf: true' -d '{"spaces":["scorestack"],"objects":[{"type":"dashboard","id":"'scorestack-scoreboard'"}],"includeReferences":true}'
 
 # Add default index template
 curl -k -XPUT -u ${USERNAME}:${PASSWORD} https://${ELASTICSEARCH_HOST}/_template/default -H 'Content-Type: application/json' -d '{"index_patterns":["check*","attrib_*","results*"],"settings":{"number_of_replicas":"0"}}'
@@ -75,17 +65,11 @@ do
   curl -kX PUT -u ${USERNAME}:${PASSWORD} https://${ELASTICSEARCH_HOST}/_security/user/${TEAM} -H 'Content-Type: application/json' -d '{"password":"changeme","roles":["common","'${TEAM}'"]}'
 
   # Add team overview dashboard
-  UUID_A=$(uuidgen)
-  UUID_B=$(uuidgen)
-  UUID_C=$(uuidgen)
-  UUID_D=$(uuidgen)
-  UUID_E=$(uuidgen)
-  UUID_F=$(uuidgen)
   INDEX="results-${TEAM}*"
   CHECKS=$(find examples -maxdepth 1 -mindepth 1 -type d -printf "%f\n" | wc -l)
-  cat dashboards/single-team-overview.json | sed -e "s/\${UUID_A}/${UUID_A}/g" | sed -e "s/\${UUID_B}/${UUID_B}/g" | sed -e "s/\${UUID_C}/${UUID_C}/g" | sed -e "s/\${UUID_D}/${UUID_D}/g" | sed -e "s/\${UUID_E}/${UUID_E}/g" | sed -e "s/\${UUID_F}/${UUID_F}/g" | sed -e "s/\${TEAM}/${TEAM}/g" | sed -e "s/\${INDEX}/${INDEX}/g" | sed -e "s/\${CHECKS}/${CHECKS}/g" > tmp-dashboard.json
+  cat dashboards/single-team-overview.json | sed -e "s/\${TEAM}/${TEAM}/g" | sed -e "s/\${INDEX}/${INDEX}/g" | sed -e "s/\${CHECKS}/${CHECKS}/g" > tmp-dashboard.json
   curl -ku ${USERNAME}:${PASSWORD} https://${KIBANA_HOST}/api/kibana/dashboards/import -H "Content-Type: application/json" -H "kbn-xsrf: true" -d @tmp-dashboard.json
-  curl -kX POST -u ${USERNAME}:${PASSWORD} https://${KIBANA_HOST}/api/spaces/_copy_saved_objects -H 'Content-Type: application/json' -H 'kbn-xsrf: true' -d '{"spaces":["scorestack"],"objects":[{"type":"dashboard","id":"'${UUID_A}'"}],"includeReferences":true}'
+  curl -kX POST -u ${USERNAME}:${PASSWORD} https://${KIBANA_HOST}/api/spaces/_copy_saved_objects -H 'Content-Type: application/json' -H 'kbn-xsrf: true' -d '{"spaces":["scorestack"],"objects":[{"type":"dashboard","id":"'scorestack-scoreboard'"}],"includeReferences":true}'
 done
 
 # Clean up

--- a/dashboards/scoreboard.json
+++ b/dashboards/scoreboard.json
@@ -2,7 +2,7 @@
   "version": "7.5.1",
   "objects": [
     {
-      "id": "${UUID_A}",
+      "id": "scorestack-scoreboard",
       "type": "dashboard",
       "updated_at": "2020-02-18T11:43:39.882Z",
       "version": "WzkzLDJd",
@@ -10,15 +10,15 @@
         "title": "Scoreboard",
         "hits": 0,
         "description": "",
-        "panelsJSON": "[{\"version\":\"7.5.1\",\"gridData\":{\"x\":12,\"y\":0,\"w\":23,\"h\":26,\"i\":\"${UUID_B}\"},\"panelIndex\":\"${UUID_B}\",\"embeddableConfig\":{},\"panelRefName\":\"panel_0\"},{\"version\":\"7.5.1\",\"gridData\":{\"x\":0,\"y\":26,\"w\":48,\"h\":5,\"i\":\"${UUID_C}\"},\"panelIndex\":\"${UUID_C}\",\"embeddableConfig\":{},\"panelRefName\":\"panel_1\"}]",
+        "panelsJSON": "[{\"version\":\"7.5.1\",\"gridData\":{\"x\":12,\"y\":0,\"w\":23,\"h\":26,\"i\":\"scorestack-scoreboard-uuid-b\"},\"panelIndex\":\"scorestack-scoreboard-uuid-b\",\"embeddableConfig\":{},\"panelRefName\":\"panel_0\"},{\"version\":\"7.5.1\",\"gridData\":{\"x\":0,\"y\":26,\"w\":48,\"h\":5,\"i\":\"scorestack-scoreboard-uuid-c\"},\"panelIndex\":\"scorestack-scoreboard-uuid-c\",\"embeddableConfig\":{},\"panelRefName\":\"panel_1\"}]",
         "optionsJSON": "{\"useMargins\":true,\"hidePanelTitles\":false}",
         "version": 1,
         "timeRestore": true,
         "timeTo": "now",
-        "timeFrom": "now-3d/d",
+        "timeFrom": "now-7d/d",
         "refreshInterval": {
           "pause": false,
-          "value": 1000
+          "value": 30000
         },
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
@@ -28,12 +28,12 @@
         {
           "name": "panel_0",
           "type": "visualization",
-          "id": "${UUID_D}"
+          "id": "scorestack-viz-all-team-status"
         },
         {
           "name": "panel_1",
           "type": "visualization",
-          "id": "${UUID_E}"
+          "id": "scorestack-viz-all-team-scores"
         }
       ],
       "migrationVersion": {
@@ -41,7 +41,7 @@
       }
     },
     {
-      "id": "${UUID_D}",
+      "id": "scorestack-viz-all-team-status",
       "type": "visualization",
       "updated_at": "2020-02-18T08:50:09.588Z",
       "version": "WzY3LDFd",
@@ -59,7 +59,7 @@
         {
           "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
           "type": "index-pattern",
-          "id": "${UUID_F}"
+          "id": "scorestack-index-pattern-results-all"
         }
       ],
       "migrationVersion": {
@@ -67,7 +67,7 @@
       }
     },
     {
-      "id": "${UUID_E}",
+      "id": "scorestack-viz-all-team-scores",
       "type": "visualization",
       "updated_at": "2020-02-18T08:36:46.200Z",
       "version": "WzYxLDFd",
@@ -85,7 +85,7 @@
         {
           "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
           "type": "index-pattern",
-          "id": "${UUID_F}"
+          "id": "scorestack-index-pattern-results-all"
         }
       ],
       "migrationVersion": {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "id": "${UUID_F}",
+      "id": "scorestack-index-pattern-results-all",
       "type": "index-pattern",
       "updated_at": "2020-02-18T08:14:38.317Z",
       "version": "WzUzLDFd",

--- a/dashboards/single-team-overview.json
+++ b/dashboards/single-team-overview.json
@@ -2,7 +2,7 @@
   "version": "7.5.1",
   "objects": [
     {
-      "id": "${UUID_A}",
+      "id": "scorestack-overview-${TEAM}",
       "type": "dashboard",
       "updated_at": "2020-02-18T11:41:27.708Z",
       "version": "WzkwLDJd",
@@ -10,7 +10,7 @@
         "title": "Overview - ${TEAM}",
         "hits": 0,
         "description": "",
-        "panelsJSON": "[{\"version\":\"7.5.1\",\"gridData\":{\"x\":0,\"y\":0,\"w\":48,\"h\":32,\"i\":\"${UUID_B}\"},\"panelIndex\":\"${UUID_B}\",\"embeddableConfig\":{},\"panelRefName\":\"panel_0\"},{\"version\":\"7.5.1\",\"gridData\":{\"x\":0,\"y\":32,\"w\":48,\"h\":13,\"i\":\"${UUID_C}\"},\"panelIndex\":\"${UUID_C}\",\"embeddableConfig\":{},\"panelRefName\":\"panel_1\"}]",
+        "panelsJSON": "[{\"version\":\"7.5.1\",\"gridData\":{\"x\":0,\"y\":0,\"w\":48,\"h\":32,\"i\":\"scorestack-overview-${TEAM}-uuid-b\"},\"panelIndex\":\"scorestack-overview-${TEAM}-uuid-b\",\"embeddableConfig\":{},\"panelRefName\":\"panel_0\"},{\"version\":\"7.5.1\",\"gridData\":{\"x\":0,\"y\":32,\"w\":48,\"h\":13,\"i\":\"scorestack-overview-${TEAM}-uuid-c\"},\"panelIndex\":\"scorestack-overview-${TEAM}-uuid-c\",\"embeddableConfig\":{},\"panelRefName\":\"panel_1\"}]",
         "optionsJSON": "{\"hidePanelTitles\":false,\"useMargins\":true}",
         "version": 1,
         "timeRestore": true,
@@ -18,7 +18,7 @@
         "timeFrom": "now-15m",
         "refreshInterval": {
           "pause": false,
-          "value": 1000
+          "value": 30000
         },
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"filter\":[]}"
@@ -28,12 +28,12 @@
         {
           "name": "panel_0",
           "type": "visualization",
-          "id": "${UUID_D}"
+          "id": "scorestack-service-status-over-time-${TEAM}"
         },
         {
           "name": "panel_1",
           "type": "visualization",
-          "id": "${UUID_E}"
+          "id": "scorestack-check-results-overview-${TEAM}"
         }
       ],
       "migrationVersion": {
@@ -41,7 +41,7 @@
       }
     },
     {
-      "id": "${UUID_D}",
+      "id": "scorestack-service-status-over-time-${TEAM}",
       "type": "visualization",
       "updated_at": "2020-02-18T11:29:39.662Z",
       "version": "Wzg2LDJd",
@@ -59,7 +59,7 @@
         {
           "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
           "type": "index-pattern",
-          "id": "${UUID_F}"
+          "id": "scorestack-index-pattern-${TEAM}"
         }
       ],
       "migrationVersion": {
@@ -67,7 +67,7 @@
       }
     },
     {
-      "id": "${UUID_E}",
+      "id": "scorestack-check-results-overview-${TEAM}",
       "type": "visualization",
       "updated_at": "2020-02-18T11:36:10.747Z",
       "version": "Wzg4LDJd",
@@ -85,7 +85,7 @@
         {
           "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
           "type": "index-pattern",
-          "id": "${UUID_F}"
+          "id": "scorestack-index-pattern-${TEAM}"
         }
       ],
       "migrationVersion": {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "id": "${UUID_F}",
+      "id": "scorestack-index-pattern-${TEAM}",
       "type": "index-pattern",
       "updated_at": "2020-02-18T11:25:48.753Z",
       "version": "WzgxLDJd",


### PR DESCRIPTION
Description
-----------

Since the colors in a visualization "flash" every time the dashboard refreshes, this PR implements a workaround by reducing the default refresh time to 30 seconds. The colors still flash, but now the dashboard doesn't have a strobe effect. Instead, the color flash works as a sort of refresh indicator.

Also, I implemented consistent saved object IDs, just because why not.

Fixes #254
Fixes #269

## Merge Checklist

- [X] I have tested this change locally to make sure it works
- [X] I have updated the documentation as necessary
- [X] I have added a release note under the [Unreleased section of the Changelog](../CHANGELOG.md#unreleased)
- [X] Any relevant labels have been added
- [X] This PR is being merged into `dev`, unless it's a PR for a release