### PR TITLE
Fix logical error preventing SSH content matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Each section organizes entries into the following subsections:
 [Unreleased]
 ------------
 
+### Dynamicbeat
+
+#### Fixed
+
+- SSH now matches content when MatchContent is true
+
+
 [0.6.1] - 2020-01-26
 --------------------
 

--- a/dynamicbeat/checks/ssh/ssh.go
+++ b/dynamicbeat/checks/ssh/ssh.go
@@ -76,7 +76,7 @@ func (d *Definition) Run(ctx context.Context) schema.CheckResult {
 	}
 
 	// Check if we are going to match content
-	if matchContent, _ := strconv.ParseBool(d.MatchContent); matchContent {
+	if matchContent, _ := strconv.ParseBool(d.MatchContent); !matchContent {
 		// If we made it here the check passes
 		result.Message = fmt.Sprintf("Command %s executed successfully: %s", d.Cmd, output)
 		result.Passed = true


### PR DESCRIPTION
Description
-----------

Hello friends, this is a small (one character) change that should handle the SSH MatchContent field correctly. I haven't tested it locally, but due to it being a tiny change, I assume it won't have any unforeseen collateral damage. I think these two structures were mixed:

[Match content when false](https://github.com/scorestack/scorestack/blob/17a9444e7574cbc60ed552933d4237bfbc795f75/dynamicbeat/checks/winrm/winrm.go#L74)
[Match content when true](https://github.com/scorestack/scorestack/blob/17a9444e7574cbc60ed552933d4237bfbc795f75/dynamicbeat/checks/mysql/mysql.go#L66)
Into [don't match content when true](https://github.com/scorestack/scorestack/blob/918a411160f59b27e6c6185fc5e221f0381cd68f/dynamicbeat/checks/ssh/ssh.go#L79)

## Merge Checklist

- [ ] I have tested this change locally to make sure it works
- [x] I have updated the documentation as necessary
- [x] I have added a release note under the [Unreleased section of the Changelog](../CHANGELOG.md#unreleased)
- [ ] Any relevant labels have been added
- [x] This PR is being merged into `dev`, unless it's a PR for a release