### PR TITLE
Ignore EOF error from SSH library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ Each section organizes entries into the following subsections:
 [Unreleased]
 ------------
 
+### Dynamicbeat
+
+#### Fixed
+
+- Spurious EOF errors when closing SSH connections are ignored (#292)
+
 [0.6.2] - 2020-02-16
 --------------------
 

--- a/dynamicbeat/checks/ssh/ssh.go
+++ b/dynamicbeat/checks/ssh/ssh.go
@@ -63,7 +63,7 @@ func (d *Definition) Run(ctx context.Context) schema.CheckResult {
 	}
 	defer func() {
 		err = session.Close()
-		if err != nil {
+		if err != nil && err.Error() != "EOF" {
 			logp.Warn("Failed to close SSH session connection: %s", err)
 		}
 	}()


### PR DESCRIPTION
Description
-----------

This PR ignores a spurious error when closing SSH sessions.

Fixes #274

## Merge Checklist

- [X] I have tested this change locally to make sure it works
- [X] I have updated the documentation as necessary
- [X] I have added a release note under the [Unreleased section of the Changelog](../CHANGELOG.md#unreleased)
- [X] Any relevant labels have been added
- [X] This PR is being merged into `dev`, unless it's a PR for a release