### PR TITLE
Fix segfault on check parse fail in dynamicbeat

### DIFF
--- a/dynamicbeat/pkg/checksource/filesystem.go
+++ b/dynamicbeat/pkg/checksource/filesystem.go
@@ -50,9 +50,10 @@ func (f *Filesystem) LoadAll() ([]check.Config, error) {
 			c, err := f.LoadCheck(fullId)
 			if err != nil {
 				zap.S().Errorf("skipping check %s due to error when loading: %s", id, err)
+			} else {
+				checks = append(checks, *c)
 			}
 
-			checks = append(checks, *c)
 		}
 	}
 


### PR DESCRIPTION
Description
-----------

This commit fixes the previous behavior of dynamicbeat crashing when an invalid check is parsed. This is called from `dynamicbeat setup checks` and would happen when adding checks to elastic, by accessing a null pointer. As the error is passed to Errorf() this still by zap's defaults results in a large stack trace, but dynamicbeat will try to upload the next check as expected. Disabling stack traces on logs like this is possible using the documentation [here](https://pkg.go.dev/go.uber.org/zap@v1.16.0?utm_source=gopls#Config.DisableStacktrace).

Fixes #305

## Merge Checklist

- [X] I have tested this change locally to make sure it works
- [X] I have updated the documentation as necessary
- [ ] I have added a release note under the [Unreleased section of the Changelog](../CHANGELOG.md#unreleased)
- [X] Any relevant labels have been added
- [X] This PR is being merged into `dev`, unless it's a PR for a release