### PR TITLE
Fix Template Overrides

### DIFF
--- a/dynamicbeat/pkg/checksource/filesystem.go
+++ b/dynamicbeat/pkg/checksource/filesystem.go
@@ -89,11 +89,9 @@ func (f *Filesystem) LoadCheck(id string) (*check.Config, error) {
 	}
 
 	// Grab team attribute overrides, if they exist
-	var overrides map[string]string
-	if team.Overrides != nil {
-		overrides = team.Overrides
-	} else {
-		overrides = make(map[string]string)
+	overrides := make(map[string]string)
+	for k, v := range team.Overrides {
+		overrides[k] = v
 	}
 
 	// Add attribute for team number if it doesn't exist

--- a/dynamicbeat/pkg/checksource/filesystem.go
+++ b/dynamicbeat/pkg/checksource/filesystem.go
@@ -157,7 +157,7 @@ func applyOverrides(overrides map[string]string, attributes map[string]string) (
 
 		// Otherwise, parse the attribute value as a template, using the
 		// overrides as keys for the template.
-		val, err := util.ApplyTemplating(v, attributes)
+		val, err := util.ApplyTemplating(v, overrides)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Description
-----------

This PR fixes a bug in the team override system that caused any checks using the template-based override method to fail. This was because the wrong map was being used to execute the attribute value templates, so the overrides were never being used.

Replacement overrides are not affected by this bug, and work as expected.

## Merge Checklist

- [X] I have tested this change locally to make sure it works
- [X] I have updated the documentation as necessary
- [x] I have added a release note under the [Unreleased section of the Changelog](../CHANGELOG.md#unreleased)
- [X] Any relevant labels have been added
- [X] This PR is being merged into `dev`, unless it's a PR for a release