### PR TITLE
fix example kibana checks

### DIFF
--- a/examples/http-kibana-auth.json
+++ b/examples/http-kibana-auth.json
@@ -6,7 +6,7 @@
     "requests": [
       {
         "host": "{{.Host}}",
-        "path": "/api/security/v1/login",
+        "path": "/internal/security/login",
         "https": true,
         "port": 5601,
         "method": "POST",
@@ -30,7 +30,7 @@
         "matchcode": true,
         "code": 200,
         "matchcontent": true,
-        "contentregex": "<script src=\"/bundles/app/kibana/bootstrap\\.js\">"
+        "contentregex": "<script src=\"/bundles/app/core/bootstrap\\.js\">"
       }
     ]
   },

--- a/examples/http-kibana.json
+++ b/examples/http-kibana.json
@@ -22,7 +22,7 @@
         "method": "GET",
         "matchcode": true,
         "matchcontent": true,
-        "contentregex": "<script src=\"/bundles/app/kibana/bootstrap\\.js\">"
+        "contentregex": "<script src=\"/bundles/app/core/bootstrap\\.js\">"
       }
     ]
   },


### PR DESCRIPTION
Description
-----------

The `/api/security/v1` routes have moved to `/internal/security/` as of Kibana 7.6.0.

Reference: https://discuss.elastic.co/t/using-authentication-api-of-kibana-api-security-v1-login-returns-404-not-found/246920/2

Also fixes the path to `bootstrap.js` in the `contentregex` check.

## Merge Checklist

- [x] I have tested this change locally to make sure it works
- [ ] I have updated the documentation as necessary
- [ ] I have added a release note under the [Unreleased section of the Changelog](../CHANGELOG.md#unreleased)
- [ ] Any relevant labels have been added
- [ ] This PR is being merged into `dev`, unless it's a PR for a release