### PR TITLE
Remove references to `stable` branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,4 +11,3 @@ Fixes #(issue)
 - [ ] I have updated the documentation as necessary
 - [ ] I have added a release note under the [Unreleased section of the Changelog](../CHANGELOG.md#unreleased)
 - [ ] Any relevant labels have been added
-- [ ] This PR is being merged into `dev`, unless it's a PR for a release

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,7 +4,7 @@ name: GitHub Pages
 on:
   push:
     branches:
-      - stable
+      - main
   workflow_dispatch:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -401,7 +401,7 @@ This release is in preparation for ISTS 2020.
 
 The initial release of Scorestack.
 
-[Unreleased]: https://github.com/scorestack/scorestack/compare/v0.8.2...dev
+[Unreleased]: https://github.com/scorestack/scorestack/compare/v0.8.2...main
 [0.8.2]: https://github.com/scorestack/scorestack/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/scorestack/scorestack/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/scorestack/scorestack/compare/v0.7.0...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Each section organizes entries into the following subsections:
 [Unreleased]
 ------------
 
+[0.8.2] - 2021-09-28
+--------------------
+
+THis release fixes a Dynamicbeat bug in the team overrides system.
+
 ### Dynamicbeat
 
 #### Fixed
@@ -396,7 +401,8 @@ This release is in preparation for ISTS 2020.
 
 The initial release of Scorestack.
 
-[Unreleased]: https://github.com/scorestack/scorestack/compare/v0.8.1...dev
+[Unreleased]: https://github.com/scorestack/scorestack/compare/v0.8.2...dev
+[0.8.2]: https://github.com/scorestack/scorestack/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/scorestack/scorestack/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/scorestack/scorestack/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/scorestack/scorestack/compare/v0.6.2...v0.7.0

--- a/README.md
+++ b/README.md
@@ -6,12 +6,10 @@ Scorestack
 
 A security competition scoring system built on the Elastic stack.
 
-The Scorestack documentation is [hosted online](https://docs.scorestack.io). The documentation is written in markdown and built with [mdBook](https://github.com/rust-lang/mdBook). If the online documentation is unavailable or you simply prefer reading the raw markdown files, take a look in [the docs folder](https://github.com/scorestack/scorestack/tree/stable/docs) of the repository.
+The Scorestack documentation is [hosted online](https://docs.scorestack.io). The documentation is written in markdown and built with [mdBook](https://github.com/rust-lang/mdBook). If the online documentation is unavailable or you simply prefer reading the raw markdown files, take a look in [the docs folder](https://github.com/scorestack/scorestack/tree/main/docs) of the repository.
 
 Questions, Comments, and Concerns
 ---------------------------------
-
-If you have any questions about Scorestack, feel free to send us an email at `devs [at] scorestack [dot] io`. We'll be happy to help resolve any issues you may have.
 
 If you think you've found a bug in Scorestack, please [submit a new issue](https://github.com/scorestack/scorestack/issues) so we can take a look and resolve it. If you need something resolved ASAP, please send us an email at `devs [at] scorestack [dot] io` after submitting a bug report. We will take a look at the issue as soon as we can and/or help you find a suitable workaround.
 

--- a/deployment/medium/ansible/playbook.yml
+++ b/deployment/medium/ansible/playbook.yml
@@ -247,7 +247,7 @@
         - Restart Kibana
 
     - name: Install plugin
-      command: /usr/share/kibana/bin/kibana-plugin --allow-root install https://github.com/scorestack/scorestack/releases/download/v0.8.1/kibana-plugin-v0.8.1.zip
+      command: /usr/share/kibana/bin/kibana-plugin --allow-root install https://github.com/scorestack/scorestack/releases/download/v0.8.2/kibana-plugin-v0.8.2.zip
       args:
         creates: /usr/share/kibana/plugins/scorestack
       notify:

--- a/deployment/small/docker/setup.sh
+++ b/deployment/small/docker/setup.sh
@@ -42,7 +42,7 @@ docker exec ${KIBANA_CONTAINER} bin/kibana-keystore create
 docker exec ${KIBANA_CONTAINER} /bin/bash -c "bin/kibana-keystore add elasticsearch.password --stdin <<< '${kibana_pass}'"
 
 # Install kibana plugin
-docker exec ${KIBANA_CONTAINER} /bin/bash -c "bin/kibana-plugin install https://github.com/scorestack/scorestack/releases/download/v0.8.1/kibana-plugin-v0.8.1.zip"
+docker exec ${KIBANA_CONTAINER} /bin/bash -c "bin/kibana-plugin install https://github.com/scorestack/scorestack/releases/download/v0.8.2/kibana-plugin-v0.8.2.zip"
 
 # Restart kibana to reload credentials from keystore
 cd config

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -11,4 +11,4 @@ A check's metadata uniquely identifies it and tells Scorestack how it should be 
 
 The rest of this section explains the parts of a check in greater detail, as well as how to write a check configuration file, how to add your checks to Kibana, and how to use the team override system to write check configurations that can be generic across all of your teams.
 
-As you read the documentation and write your check files, it may be useful to consult the example check definitions in the [`examples/` folder of the repository](https://github.com/scorestack/scorestack/tree/stable/examples).
+As you read the documentation and write your check files, it may be useful to consult the example check definitions in the [`examples/` folder of the repository](https://github.com/scorestack/scorestack/tree/main/examples).

--- a/docs/checks/reference.md
+++ b/docs/checks/reference.md
@@ -1,7 +1,7 @@
 Check Reference
 ===============
 
-This section of the documentation contains a reference to each of the check types available in Dynamicbeat. Each page within this section covers the available parameters for a specific check type. Example check definitions for all check types can be found under [the `examples` folder in the Scorestack repository](https://github.com/scorestack/scorestack/tree/stable/examples).
+This section of the documentation contains a reference to each of the check types available in Dynamicbeat. Each page within this section covers the available parameters for a specific check type. Example check definitions for all check types can be found under [the `examples` folder in the Scorestack repository](https://github.com/scorestack/scorestack/tree/main/examples).
 
 Please note that the _Type_ listed in the tables on these pages refers to the type that must be used in the JSON document. For example, if the _type_ is _string_, then value for that parameter in the JSON document must be a `"string"`.
 

--- a/docs/deployment/cloning.md
+++ b/docs/deployment/cloning.md
@@ -1,14 +1,14 @@
 Cloning the Repository
 ======================
 
-Whenever you need to deploy Scorestack, you need to make sure you're cloning the right branch. In most cases, cloning directly from the `stable` branch (which is the default) is fine.
-
+If you're just testing out Scorestack, cloning the default branch (`main`) should be fine in almost all cases:
 ```shell
-git clone --branch stable https://github.com/scorestack/scorestack.git
+git clone https://github.com/scorestack/scorestack.git
 ```
 
-However, if you would like to deploy a specific version of Scorestack, just pass the tag of the version you want to deploy to the `--branch` argument of `git clone`. For example, to deploy Scorestack version 0.5.0, you would run `git clone --branch v0.5.0 https://github.com/scorestack/scorestack.git`.
+However, the `main` branch is the primary branch used for development. While we do our best to never merge broken code into `main`, there's no guarantees that what's on `main` will always work as expected.
 
-If you just want to use the latest release, the `stable` branch is fine - it always points at the latest stable release.
-
-If you want to live life on the edge and try out an unstable release or unreleased changes, try cloning the `dev` branch instead! Just note that it `dev` is the unstable development branch, so there's no guarantees that things will work for you.
+Therefore, whenever you deploy Scorestack in a production environment (such as for active competitions) you should always use the `--branch` argument of `git clone` to specify the exact version you want to clone. For example, this command will clone [Scorestack 0.8.2](https://github.com/scorestack/scorestack/releases/tag/v0.8.2):
+```shell
+git clone --branch v0.8.2 https://github.com/scorestack/scorestack.git
+```

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -9,7 +9,7 @@ A security competition scoring system built on the Elastic stack.
 Quickstart
 ----------
 
-To get up and running checking your services with Scorestack as fast as possible, follow the deployment guide for the [small deployment with Docker](./deployment/small.md#docker-deployment). After that, read up on [adding checks](./checks/adding_checks.md), and then take a look at the example checks in the [`examples` folder in the repository](https://github.com/scorestack/scorestack/tree/stable/examples) - you should be able to find examples to get you started for several of your services! After you've added some checks, check out the [Dynamicbeat deployment guide](./deployment/dynamicbeat.md) to get Dynamicbeat up and running.
+To get up and running checking your services with Scorestack as fast as possible, follow the deployment guide for the [small deployment with Docker](./deployment/small.md#docker-deployment). After that, read up on [adding checks](./checks/adding_checks.md), and then take a look at the example checks in the [`examples` folder in the repository](https://github.com/scorestack/scorestack/tree/main/examples) - you should be able to find examples to get you started for several of your services! After you've added some checks, check out the [Dynamicbeat deployment guide](./deployment/dynamicbeat.md) to get Dynamicbeat up and running.
 
 Documentation Overview
 ----------------------

--- a/kibana-plugin/package.json
+++ b/kibana-plugin/package.json
@@ -1,11 +1,11 @@
 {
   "name": "scorestack",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "A Kibana plugin for viewing and modifying Scorestack checks and attributes.",
   "private": true,
   "scripts": {
     "prebuild": "node ../../scripts/build_kibana_platform_plugins --verbose --dist --filter scorestack",
-    "build": "plugin-helpers build --build-version 0.8.1 --kibana-version 7.9.2",
+    "build": "plugin-helpers build --build-version 0.8.2 --kibana-version 7.9.2",
     "kbn": "node ../../scripts/kbn",
     "lint": "eslint --ignore-path .gitignore --color .",
     "plugin-helpers": "plugin-helpers",


### PR DESCRIPTION
Description
-----------

This PR replaces references to the `stable` branch with references to `main` in preparation for a transition to a simpler single-branch workflow.

## Merge Checklist

- [X] I have tested this change locally to make sure it works
- [X] I have updated the documentation as necessary
- [ ] I have added a release note under the [Unreleased section of the Changelog](../CHANGELOG.md#unreleased)
- [ ] Any relevant labels have been added