### PR TITLE
Add threadding for document indexing in esclient.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ Each section organizes entries into the following subsections:
 
 #### Added
 - Git check type (#346)
-
+#### Changed 
+- Added threadding to document indexing
 ## [0.8.2] - 2021-09-28
 
 THis release fixes a Dynamicbeat bug in the team overrides system.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Each section organizes entries into the following subsections:
 #### Added
 - Git check type (#346)
 #### Changed 
-- Added threadding to document indexing
+- Added threadding to document indexing (#347)
 ## [0.8.2] - 2021-09-28
 
 THis release fixes a Dynamicbeat bug in the team overrides system.


### PR DESCRIPTION
Description
-----------

Added threadding for document indexing in esclient.go. 

We found this to be a bottleneck that caused scorechecks to fall behind over time regardless of the resources given to the dynamicbeat box or the ELK box. This code modification was used for ISTS with no issues. 

## Merge Checklist

- [X] I have tested this change locally to make sure it works
- [X] I have updated the documentation as necessary (Doesn't Apply)
- [X] I have added a release note under the [Unreleased section of the Changelog](../CHANGELOG.md#unreleased)
- [X] Any relevant labels have been added