### PR TITLE
Bump Go to 1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Each section organizes entries into the following subsections:
 #### Added
 - Git check type (#346)
 
+#### Changed
+- Bumped Go to 1.20 (#384)
+- Bumped golangci-lint to v1.52.2 (#384)
+
 ## [0.8.2] - 2021-09-28
 
 THis release fixes a Dynamicbeat bug in the team overrides system.

--- a/dockerfiles/dynamicbeat.Dockerfile
+++ b/dockerfiles/dynamicbeat.Dockerfile
@@ -53,34 +53,17 @@ FROM ci as devcontainer
 # Install packages ############################################################
 
 # Install Go tools
-RUN go get -v golang.org/x/tools/...
+RUN go install -v golang.org/x/tools/...@latest 2>&1
 
 # Install golangci-lint
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2
 
 # Install a bunch of packages that vscode wants. I don't really know what all
 # of these are, but they make the go extension work properly.
-RUN GO111MODULE=on go get -v \
-    honnef.co/go/tools/...@latest \
-    golang.org/x/tools/cmd/gorename@latest \
-    golang.org/x/tools/cmd/goimports@latest \
-    golang.org/x/tools/cmd/guru@latest \
-    golang.org/x/lint/golint@latest \
-    github.com/mdempsky/gocode@latest \
-    github.com/cweill/gotests/...@latest \
-    github.com/haya14busa/goplay/cmd/goplay@latest \
-    github.com/sqs/goreturns@latest \
-    github.com/josharian/impl@latest \
-    github.com/davidrjenni/reftools/cmd/fillstruct@latest \
-    github.com/uudashr/gopkgs/...  \
-    github.com/ramya-rao-a/go-outline@latest  \
-    github.com/acroca/go-symbols@latest  \
-    github.com/godoctor/godoctor@latest  \
-    github.com/rogpeppe/godef@latest  \
-    github.com/zmb3/gogetdoc@latest \
-    github.com/fatih/gomodifytags@latest  \
-    github.com/mgechev/revive@latest  \
-    github.com/go-delve/delve/cmd/dlv@latest 2>&1
-RUN go get -v github.com/alecthomas/gometalinter 2>&1
-RUN go get -x -d github.com/stamblerre/gocode 2>&1
-RUN go build -o $GOPATH/bin/gocode-gomod github.com/stamblerre/gocode
+RUN go install -v github.com/cweill/gotests/gotests@v1.6.0 2>&1
+RUN go install -v github.com/fatih/gomodifytags@v1.16.0 2>&1
+RUN go install -v github.com/josharian/impl@v1.1.0 2>&1
+RUN go install -v github.com/haya14busa/goplay/cmd/goplay@v1.0.0 2>&1
+RUN go install -v github.com/go-delve/delve/cmd/dlv@latest 2>&1
+RUN go install -v honnef.co/go/tools/cmd/staticcheck@latest 2>&1
+RUN go install -v golang.org/x/tools/gopls@latest 2>&1

--- a/dockerfiles/dynamicbeat.Dockerfile
+++ b/dockerfiles/dynamicbeat.Dockerfile
@@ -56,7 +56,7 @@ FROM ci as devcontainer
 RUN go get -v golang.org/x/tools/...
 
 # Install golangci-lint
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.1
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2
 
 # Install a bunch of packages that vscode wants. I don't really know what all
 # of these are, but they make the go extension work properly.

--- a/dockerfiles/dynamicbeat.Dockerfile
+++ b/dockerfiles/dynamicbeat.Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-FROM golang:1.16.2 as ci
+FROM golang:1.20 as ci
 ###############################################################################
 
 RUN apt-get update
@@ -31,7 +31,7 @@ RUN chown -R $USER_UID:$USER_GID /home/$USERNAME/scorestack
 
 # Install build dependencies
 RUN apt-get install -y \
-    python-pip \
+    python3-pip \
     virtualenv \
     git
 

--- a/dockerfiles/scripts/dynamicbeat/lint.sh
+++ b/dockerfiles/scripts/dynamicbeat/lint.sh
@@ -4,5 +4,5 @@ set -euxo pipefail
 export PATH="$PATH:$GOPATH/bin"
 cd $HOME/scorestack/dynamicbeat
 make
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.1
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2
 golangci-lint run -v

--- a/dynamicbeat/go.mod
+++ b/dynamicbeat/go.mod
@@ -1,6 +1,6 @@
 module github.com/scorestack/scorestack/dynamicbeat
 
-go 1.16
+go 1.20
 
 require (
 	github.com/denisenkom/go-mssqldb v0.9.0
@@ -23,4 +23,58 @@ require (
 	golang.org/x/crypto v0.3.0
 	gopkg.in/yaml.v2 v2.4.0
 	gosrc.io/xmpp v0.5.1
+)
+
+require (
+	github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c // indirect
+	github.com/ChrisTrenkamp/goxpath v0.0.0-20190607011252-c5096ec8773d // indirect
+	github.com/Microsoft/go-winio v0.5.2 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
+	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/cloudflare/circl v1.1.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/emersion/go-sasl v0.0.0-20191210011802-430746ea8b9b // indirect
+	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/go-asn1-ber/asn1-ber v1.5.1 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/gofrs/uuid v3.2.0+incompatible // indirect
+	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
+	github.com/google/uuid v1.1.1 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/imdario/mergo v0.3.13 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
+	github.com/jackc/pgconn v1.8.0 // indirect
+	github.com/jackc/pgio v1.0.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgproto3/v2 v2.0.6 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
+	github.com/jackc/pgtype v1.6.2 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/kevinburke/ssh_config v1.2.0 // indirect
+	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/masterzen/simplexml v0.0.0-20160608183007-4572e39b1ab9 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/pjbgf/sha1cd v0.3.0 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/sergi/go-diff v1.1.0 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/skeema/knownhosts v1.1.0 // indirect
+	github.com/spf13/afero v1.1.2 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/jwalterweatherman v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	go.uber.org/atomic v1.6.0 // indirect
+	go.uber.org/multierr v1.5.0 // indirect
+	golang.org/x/net v0.2.0 // indirect
+	golang.org/x/sys v0.3.0 // indirect
+	golang.org/x/text v0.4.0 // indirect
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
+	gopkg.in/ini.v1 v1.51.0 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	nhooyr.io/websocket v1.6.5 // indirect
 )

--- a/dynamicbeat/go.sum
+++ b/dynamicbeat/go.sum
@@ -181,7 +181,6 @@ github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -200,7 +199,6 @@ github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2 h1:JVX6jT/XfzNqIjye47
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2/go.mod h1:fGZlG77KXmcq05nJLRkk0+p82V8B8Dw8KN2/V9c/OAE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
-github.com/jackc/pgproto3 v1.1.0 h1:FYYE4yRw+AgI8wXIinMlNjBbp/UitDJwfj5LqqewP1A=
 github.com/jackc/pgproto3 v1.1.0/go.mod h1:eR5FA3leWg7p9aeAqi37XOTgTIbkABlvcPB3E5rlc78=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190420180111-c116219b62db/go.mod h1:bhq50y+xrl9n5mRYyCBFKkpRVTLYJVWeCc+mEAI3yXA=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod h1:uH0AWtUmuShn0bcesswc4aBTWGvw0cAxIJp+6OB//Wg=

--- a/dynamicbeat/pkg/checksource/filesystem.go
+++ b/dynamicbeat/pkg/checksource/filesystem.go
@@ -3,7 +3,6 @@ package checksource
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -21,7 +20,7 @@ type Filesystem struct {
 }
 
 func (f *Filesystem) LoadAll() ([]check.Config, error) {
-	files, err := ioutil.ReadDir(f.Path)
+	files, err := os.ReadDir(f.Path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read contents of directory '%s': %s", f.Path, err)
 	}

--- a/dynamicbeat/pkg/checktypes/ftp/ftp.go
+++ b/dynamicbeat/pkg/checktypes/ftp/ftp.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"regexp"
 	"strconv"
 	"time"
@@ -86,7 +86,7 @@ func (d *Definition) Run(ctx context.Context) check.Result {
 	}
 	defer resp.Close()
 
-	content, err := ioutil.ReadAll(resp)
+	content, err := io.ReadAll(resp)
 	if err != nil {
 		result.Message = fmt.Sprintf("Could not read file %s contents : %s", d.File, err)
 		return result

--- a/dynamicbeat/pkg/checktypes/http/http.go
+++ b/dynamicbeat/pkg/checktypes/http/http.go
@@ -6,7 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"regexp"
@@ -175,7 +175,7 @@ func request(ctx context.Context, client *http.Client, r Request) (bool, *string
 	var matchStr string
 	if r.MatchContent {
 		// Read response body
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return false, nil, fmt.Errorf("Recieved error when reading response body: %s", err)
 		}

--- a/dynamicbeat/pkg/checktypes/http/http.go
+++ b/dynamicbeat/pkg/checktypes/http/http.go
@@ -189,7 +189,7 @@ func request(ctx context.Context, client *http.Client, r Request) (bool, *string
 			return false, nil, fmt.Errorf("recieved bad response body")
 		}
 		matches := regex.FindSubmatch(body)
-		matchStr = fmt.Sprintf("%s", matches[len(matches)-1])
+		matchStr = string(matches[len(matches)-1])
 	}
 
 	// If we've reached this point, then the check succeeded

--- a/dynamicbeat/pkg/checktypes/smb/smb.go
+++ b/dynamicbeat/pkg/checktypes/smb/smb.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"regexp"
 	"time"
@@ -92,7 +91,7 @@ func (d *Definition) Run(ctx context.Context) check.Result {
 	}
 
 	// Read from the file
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		result.Message = fmt.Sprintf("Error reading the file contents : %s", err)
 		return result


### PR DESCRIPTION
Description
-----------

Merging PR #346 broke the CI for building dynamicbeat. This is because the go-git module that was added depends on a version of the sys module that requires Go 1.17 or newer.

This PR bumps Go to 1.20 which is the latest stable release at the time of this PR for future proofing. This also bumps golangci-lint to v1.52.2 as it complains otherwise. All new linting issues have also been fixed.

## Merge Checklist

- [x] I have tested this change locally to make sure it works
- [x] I have updated the documentation as necessary (Not Required)
- [x] I have added a release note under the [Unreleased section of the Changelog](../CHANGELOG.md#unreleased)
- [x] Any relevant labels have been added