### PR TITLE
Bugfix Http Check Fails on Layer 7 LB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Each section organizes entries into the following subsections:
 ### Dynamicbeat
 
 #### Added
+- HTTP check host support
 - Git check type (#346)
 - Added threadding to document indexing (#347)
 

--- a/docs/checks/reference/http.md
+++ b/docs/checks/reference/http.md
@@ -36,3 +36,7 @@ One example of using the `StoreValue` attribute is the `http-kolide` example che
 The saved value is made available through the same method as attributes - just insert `{{.SavedValue}}` into your check wherever you would like it to be used.
 
 Please note that only one value can be stored using `StoreValue`. If you already have a value saved, and attempt to save another one, then the original value will be overwritten.
+
+`Headers` Parameter
+----------------------
+When the host header is present it gets added to the Go request instead.

--- a/dynamicbeat/pkg/checktypes/http/http.go
+++ b/dynamicbeat/pkg/checktypes/http/http.go
@@ -148,12 +148,24 @@ func request(ctx context.Context, client *http.Client, r Request) (bool, *string
 	}
 	url := fmt.Sprintf("%s://%s:%d%s", schema, r.Host, r.Port, r.Path)
 
+	targetHost := ""
+	if h, exists := r.Headers["Host"]; exists {
+		targetHost = h
+		// Remove Host from the headers as it will be directly on the request
+		delete(r.Headers, "Host")
+	}
+
 	// Construct request
 	req, err := http.NewRequestWithContext(ctx, r.Method, url, strings.NewReader(r.Body))
 	if err != nil {
 		return false, nil, fmt.Errorf("Error constructing request: %s", err)
 	}
 
+	// Set the Host header directly on the request if specified
+	if targetHost != "" {
+		req.Host = targetHost
+	}
+	
 	// Add headers
 	for k, v := range r.Headers {
 		req.Header[k] = []string{v}

--- a/dynamicbeat/pkg/checktypes/http/http.go
+++ b/dynamicbeat/pkg/checktypes/http/http.go
@@ -148,24 +148,18 @@ func request(ctx context.Context, client *http.Client, r Request) (bool, *string
 	}
 	url := fmt.Sprintf("%s://%s:%d%s", schema, r.Host, r.Port, r.Path)
 
-	targetHost := ""
-	if h, exists := r.Headers["Host"]; exists {
-		targetHost = h
-		// Remove Host from the headers as it will be directly on the request
-		delete(r.Headers, "Host")
-	}
-
 	// Construct request
 	req, err := http.NewRequestWithContext(ctx, r.Method, url, strings.NewReader(r.Body))
 	if err != nil {
 		return false, nil, fmt.Errorf("Error constructing request: %s", err)
 	}
 
-	// Set the Host header directly on the request if specified
-	if targetHost != "" {
-		req.Host = targetHost
+	// Handle Host header specially if present
+	if h, exists := r.Headers["Host"]; exists {
+		req.Host = h
+		delete(r.Headers, "Host")
 	}
-	
+
 	// Add headers
 	for k, v := range r.Headers {
 		req.Header[k] = []string{v}


### PR DESCRIPTION
Description
-----------
Issue: Layer 7 load balancers do not work with http checks

Fix when the hosts header is present configure the go requests with the domain instead

## Merge Checklist

- [X] I have tested this change locally to make sure it works
  - Change was used for checks in the 2025 NECCDC
- [X] I have updated the documentation as necessary
- [X] I have added a release note under the [Unreleased section of the Changelog](../CHANGELOG.md#unreleased)